### PR TITLE
Add more models and user role

### DIFF
--- a/app/models/experience_level.rb
+++ b/app/models/experience_level.rb
@@ -1,0 +1,2 @@
+class ExperienceLevel < ApplicationRecord
+end

--- a/app/models/job_type.rb
+++ b/app/models/job_type.rb
@@ -1,0 +1,2 @@
+class JobType < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
-  enum role: { regular: 0, admin: 10 }
+  enum :role, { regular: 0, admin: 10 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
+
+  enum role: { regular: 0, admin: 10 }
 end

--- a/db/migrate/20250306231309_create_job_types.rb
+++ b/db/migrate/20250306231309_create_job_types.rb
@@ -1,0 +1,9 @@
+class CreateJobTypes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :job_types do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250306231430_add_role_to_user.rb
+++ b/db/migrate/20250306231430_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/migrate/20250306231757_create_experience_levels.rb
+++ b/db/migrate/20250306231757_create_experience_levels.rb
@@ -1,0 +1,9 @@
+class CreateExperienceLevels < ActiveRecord::Migration[8.0]
+  def change
+    create_table :experience_levels do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_06_213919) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_06_231757) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -18,6 +18,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_06_213919) do
     t.string "name"
     t.string "website_url"
     t.string "contact_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "experience_levels", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -31,6 +37,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_06_213919) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["company_profile_id"], name: "index_job_postings_on_company_profile_id"
+  end
+
+  create_table "job_types", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -47,6 +59,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_06_213919) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", default: 0
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/spec/factories/experience_levels.rb
+++ b/spec/factories/experience_levels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :experience_level do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/job_types.rb
+++ b/spec/factories/job_types.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :job_type do
+    name { "MyString" }
+  end
+end

--- a/spec/models/experience_level_spec.rb
+++ b/spec/models/experience_level_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ExperienceLevel, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/job_type_spec.rb
+++ b/spec/models/job_type_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe JobType, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This commit adds 2 new models: JobType and ExperienceLevel, that should be  managed by admin users.

This commit also adds an enum attribute to user called `role` to specify if an user is regular or admin.