### PR TITLE
Fix: Correção de bug no tailwind que impedia o servidor de abrir.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.4.2
 RUN apt update -y
 RUN apt install chromium watchman -y --no-install-recommends
 
-WORKDIR app
+WORKDIR /app
 
 COPY Gemfile . 
 COPY Gemfile.lock .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY Gemfile.lock .
 
 RUN bundle install
 
-CMD [ "bin/dev" ]
+CMD [ "bin/setup" ]

--- a/bin/setup
+++ b/bin/setup
@@ -28,7 +28,8 @@ FileUtils.chdir APP_ROOT do
 
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
+    system "rm -f tmp/pids/server.pid > /dev/null 2>&1"
     STDOUT.flush # flush the output before exec(2) so that it displays
-    exec "bin/dev"
+    exec "sh -c 'bin/dev'"
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   app:
     build: .
     tty: true
-    command: sh -c 'rm -f tmp/pids/server.pid && rails db:prepare && bin/dev'
     ports:
       - 3000:3000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   app:
     build: .
+    tty: true
+    command: sh -c 'rm -f tmp/pids/server.pid && rails db:prepare && bin/dev'
     ports:
       - 3000:3000
     depends_on:


### PR DESCRIPTION
Este PR soluciona um problema que acontecia ao tentar subir o servidor com `bin/dev`, onde o tailwind dava erro ao rodar o comando  `tailwindcss:watch`. Para que o `tailwindcss:watch` funcione no ambiente docker, é necessário fazer algumas configurações a mais. 

![image](https://github.com/user-attachments/assets/dec5d2f2-f65d-4328-8090-3150145a9d91)
